### PR TITLE
Fix nullbyte on Transaction body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ compile_environment.yml
 *.so
 .vscode/
 dist/
+.idea/
+cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,22 @@ project(modsecurity)
 
 set(PYBIND11_CPP_STANDARD -std=c++11)
 
-set(LIBRARIES modsecurity)
+
+# cmake .. -DMODSEC_PATH="/path/to/modsec/install/directory"
+# set(MODSEC_PATH /opt/ModSecurity/)
+
+if (EXISTS "${MODSEC_PATH}")
+    set(LIB_DIR "${MODSEC_PATH}/lib")
+    set(INC_DIR "${MODSEC_PATH}/include")
+
+    FIND_LIBRARY(MODSEC_LIBRARY modsecurity ${LIB_DIR})
+else()
+    set(LIB_DIR "")
+    set(INC_DIR "")
+
+    set(MODSEC_LIBRARY modsecurity)
+endif()
+
 
 # Conda support
 set(INCLUDES ${INCLUDES} $ENV{CONDA_PREFIX}/include)
@@ -11,5 +26,5 @@ link_directories($ENV{CONDA_PREFIX}/lib)
 
 add_subdirectory(pybind11)
 pybind11_add_module(ModSecurity src/main.cpp src/action.cpp src/anchored_set_variable.cpp src/anchored_variable.cpp src/audit_log.cpp src/collection.cpp src/collections.cpp src/debug_log.cpp src/intervention.cpp src/transaction.cpp src/modsecurity.cpp src/rule_message.cpp src/rule.cpp src/rules_exceptions.cpp src/rules_properties.cpp src/rules.cpp src/variable_origin.cpp src/variable_value.cpp)
-include_directories(${INCLUDES})
-target_link_libraries(ModSecurity PRIVATE ${LIBRARIES})
+include_directories(${INCLUDES} ${INC_DIR})
+target_link_libraries(ModSecurity PRIVATE ${MODSEC_LIBRARY})

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -29,7 +29,7 @@ void init_transaction(py::module &m)
         .def("addRequestHeader", (int (Transaction::*)(const unsigned char *, size_t, const unsigned char *, size_t)) & Transaction::addRequestHeader)
         .def("processRequestBody", &Transaction::processRequestBody)
         .def("appendRequestBody", [](Transaction &tr, std::string &str) {
-            return tr.appendRequestBody((const unsigned char*) str.c_str(), str.length() + 1);
+            return tr.appendRequestBody((const unsigned char*) str.c_str(), str.length());
         })
         .def("requestBodyFromFile", &Transaction::requestBodyFromFile)
         .def("processResponseHeaders", &Transaction::processResponseHeaders)
@@ -38,7 +38,7 @@ void init_transaction(py::module &m)
         .def("addResponseHeader", (int (Transaction::*)(const unsigned char *, size_t, const unsigned char *, size_t)) & Transaction::addResponseHeader)
         .def("processResponseBody", &Transaction::processResponseBody)
         .def("appendResponseBody", [](Transaction &tr, std::string &str) {
-            return tr.appendResponseBody((const unsigned char*) str.c_str(), str.length() + 1);
+            return tr.appendResponseBody((const unsigned char*) str.c_str(), str.length());
         })
         .def("processLogging", &Transaction::processLogging)
         .def("updateStatusCode", &Transaction::updateStatusCode)


### PR DESCRIPTION
- Add the possibility to use a custom Modsecurity path on compilation.
- Fix nullbyte on Transaction body:

The body size is misscalculated which cause a null byte transfert to Modsecurity e.g:

```
POST /wp-login.php HTTP/1.1
...
...

log=admin&pwd=admin&wp-submit=Log In&redirect_to=https://www.example.com/wp-admin/&testcookie=1
```

====
```
Matched "Operator `ValidadeByteRange\' with parameter `1-255\' against variable `ARGS:testcookie\' (Value: `1\\x00\' )
```