### PR TITLE
BUGFIX: m_data property should return a python bytes instead of str

### DIFF
--- a/src/rule_message.cpp
+++ b/src/rule_message.cpp
@@ -25,7 +25,14 @@ void init_rule_message(py::module &m)
         .def_static("_errorLogTail", (std::string (*) (const RuleMessage *)) &RuleMessage::_errorLogTail)
         .def_readwrite("m_accuracy", &RuleMessage::m_accuracy)
         .def_readwrite("m_clientIpAddress", &RuleMessage::m_clientIpAddress)
-        .def_readwrite("m_data", &RuleMessage::m_data)
+
+        // .def_readwrite("m_data", &RuleMessage::m_data)
+        .def_property("m_data", [](const RuleMessage& rm) {
+          return py::bytes(rm.m_data);
+        }, [](RuleMessage& rm, const std::string m_data) {
+          rm.m_data = m_data;
+        }, py::return_value_policy::copy)
+
         .def_readwrite("m_id", &RuleMessage::m_id)
         .def_readwrite("m_isDisruptive", &RuleMessage::m_isDisruptive)
         .def_readwrite("m_match", &RuleMessage::m_match)


### PR DESCRIPTION
When a C++ function returns a `std::string` or `char*` to a Python caller,
pybind11 will assume that the string is valid UTF-8 and will decode it to a native Python str.

In some cases the `m_data` does not contains a valid UTF-8 encoding
and pybind11 will raise a `UnicodeDecodeError`.
see: [pybind11 doc](https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html)

Since it contains an HTTP body, m_data should return a python bytes.